### PR TITLE
Fix postinstall error with Node >=18 and Electron

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+    "variables": {
+        "openssl_fips" : "0" 
+    },
     "targets": [
         {
             "target_name": "win32_displayconfig",


### PR DESCRIPTION
Fix error on rebuilding packages step

```
gyp: name 'openssl_fips' is not defined while evaluating condition 'openssl_fips != ""' in binding.gyp while trying to load binding.gyp
```